### PR TITLE
Enable pretty permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,6 +98,8 @@ liquid:
 
 incremental         : false
 
+permalink: pretty
+
 exclude:
   - LICENSE
   - README.md


### PR DESCRIPTION
Cloudflare Pages removes the `.html` suffix from URIs: https://community.cloudflare.com/t/cloudflare-pages-truncates-urls-by-removing-the-html-extension/609238/5